### PR TITLE
fix(plugin): 修复存储插件隔离、自嵌套 rename、WebDAV 选项与打包/CI 问题

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit -- --run
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Run e2e tests
         run: yarn test:e2e
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,14 +3,13 @@
   "version": "0.1.0",
   "description": "A WebDAV-like file system interface using IndexedDB for browser-based file storage",
   "type": "module",
-  "main": "./dist/file-system.umd.js",
+  "main": "./dist/file-system.umd.cjs",
   "module": "./dist/file-system.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "import": "./dist/file-system.es.js",
-      "require": "./dist/file-system.umd.js",
+      "require": "./dist/file-system.umd.cjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'FileSystem',
       formats: ['es', 'umd'],
-      fileName: (format) => `file-system.${format}.js`,
+      fileName: (format) =>
+        format === 'umd' ? 'file-system.umd.cjs' : 'file-system.es.js',
     },
     rollupOptions: {
       external: [],

--- a/packages/plugin-indexeddb/package.json
+++ b/packages/plugin-indexeddb/package.json
@@ -3,14 +3,13 @@
   "version": "0.1.0",
   "description": "IndexedDB storage plugin for @system-ui-js/file-system-browser",
   "type": "module",
-  "main": "./dist/file-system-plugin-indexeddb.umd.js",
+  "main": "./dist/file-system-plugin-indexeddb.umd.cjs",
   "module": "./dist/file-system-plugin-indexeddb.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "import": "./dist/file-system-plugin-indexeddb.es.js",
-      "require": "./dist/file-system-plugin-indexeddb.umd.js",
+      "require": "./dist/file-system-plugin-indexeddb.umd.cjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/plugin-indexeddb/src/file-descriptors.ts
+++ b/packages/plugin-indexeddb/src/file-descriptors.ts
@@ -1,0 +1,87 @@
+import type { FsPluginContext } from '@system-ui-js/file-system-browser';
+
+export function createFileDescriptorHandlers(
+  ctx: FsPluginContext,
+  namespaceReady: Promise<unknown>,
+  toStoragePath: (path: string) => string
+) {
+  const openHandles = new Map<
+    number,
+    Awaited<ReturnType<FsPluginContext['baseFs']['open']>>
+  >();
+
+  const getHandle = (fd: number, operation: string) => {
+    const handle = openHandles.get(fd);
+    if (!handle) throw new Error(`EBADF: bad file descriptor, ${operation}`);
+    return handle;
+  };
+
+  const close = async (fd: number) => {
+    const handle = getHandle(fd, 'close');
+    openHandles.delete(fd);
+    ctx.releaseFd(fd);
+    await handle.close();
+  };
+
+  return {
+    getStorageFd(fd: number, operation: string) {
+      return getHandle(fd, operation).fd;
+    },
+    handlers: {
+      async open(path: string, flags: string, mode?: number) {
+        await namespaceReady;
+        const storageHandle = await ctx.baseFs.open(
+          toStoragePath(path),
+          flags,
+          mode
+        );
+        const fd = ctx.createFd(path, flags);
+        openHandles.set(fd, storageHandle);
+        return {
+          fd,
+          close: () => close(fd),
+          read(
+            buffer: Uint8Array,
+            offset: number,
+            length: number,
+            position: number | null
+          ) {
+            return getHandle(fd, 'read').read(buffer, offset, length, position);
+          },
+          write(
+            buffer: Uint8Array | string,
+            offset?: number,
+            length?: number,
+            position?: number | null
+          ) {
+            return getHandle(fd, 'write').write(
+              buffer,
+              offset,
+              length,
+              position
+            );
+          },
+        };
+      },
+      read(
+        fd: number,
+        buffer: Uint8Array,
+        offset: number,
+        length: number,
+        position: number | null
+      ) {
+        return getHandle(fd, 'read').read(buffer, offset, length, position);
+      },
+      write(
+        fd: number,
+        buffer: Uint8Array | string,
+        offset?: number,
+        length?: number,
+        position?: number | null
+      ) {
+        return getHandle(fd, 'write').write(buffer, offset, length, position);
+      },
+      close,
+    },
+  };
+}

--- a/packages/plugin-indexeddb/src/index.test.ts
+++ b/packages/plugin-indexeddb/src/index.test.ts
@@ -1,0 +1,126 @@
+import {
+  Buffer,
+  fs,
+  registerPlugin,
+  unregisterPlugin,
+  usePlugin,
+} from '@system-ui-js/file-system-browser';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createIndexedDBStoragePlugin } from './index';
+
+describe('indexeddb storage plugin', () => {
+  beforeEach(() => {
+    unregisterPlugin('indexeddb-isolation');
+  });
+
+  afterEach(() => {
+    unregisterPlugin('indexeddb-isolation');
+  });
+
+  it('isolates files between separate mount paths', async () => {
+    // Given: two IndexedDB instances mounted into the same virtual filesystem.
+    registerPlugin('indexeddb-isolation', createIndexedDBStoragePlugin);
+    usePlugin('indexeddb-isolation', { mountPath: '/left' });
+    usePlugin('indexeddb-isolation', { mountPath: '/right' });
+
+    // When: the same local path is written through both mounts.
+    await fs.promises.writeFile(
+      '/left/shared.txt',
+      Buffer.fromString('left'),
+      'utf8'
+    );
+    await fs.promises.writeFile(
+      '/right/shared.txt',
+      Buffer.fromString('right'),
+      'utf8'
+    );
+
+    // Then: each mount retains its own value.
+    await expect(
+      fs.promises.readFile('/left/shared.txt', 'utf8')
+    ).resolves.toBe('left');
+    await expect(
+      fs.promises.readFile('/right/shared.txt', 'utf8')
+    ).resolves.toBe('right');
+  });
+
+  it('resolves absolute symlink targets inside a non-root mount', async () => {
+    // Given: an IndexedDB plugin mounted below the virtual root.
+    registerPlugin('indexeddb-isolation', createIndexedDBStoragePlugin);
+    usePlugin('indexeddb-isolation', { mountPath: '/data' });
+    await fs.promises.writeFile(
+      '/data/target.txt',
+      Buffer.fromString('target'),
+      'utf8'
+    );
+
+    // When: a link uses the public, mount-qualified target path.
+    await fs.promises.symlink('/data/target.txt', '/data/link.txt');
+
+    // Then: following the link stays inside this mount's namespace.
+    await expect(fs.promises.readFile('/data/link.txt', 'utf8')).resolves.toBe(
+      'target'
+    );
+  });
+
+  it('keeps file descriptors inside the mounted namespace', async () => {
+    // Given: a file opened through a non-root IndexedDB mount.
+    registerPlugin('indexeddb-isolation', createIndexedDBStoragePlugin);
+    usePlugin('indexeddb-isolation', { mountPath: '/data' });
+    await fs.promises.writeFile(
+      '/data/file.txt',
+      Buffer.fromString('before'),
+      'utf8'
+    );
+    const handle = await fs.promises.open('/data/file.txt', 'r+');
+
+    // When: the public descriptor API writes through the returned descriptor.
+    await fs.promises.write(handle.fd, Buffer.fromString('after'), 0, 5, 0);
+    await fs.promises.close(handle.fd);
+
+    // Then: the mounted file is updated without escaping to the base root.
+    await expect(fs.promises.readFile('/data/file.txt', 'utf8')).resolves.toBe(
+      'aftere'
+    );
+  });
+
+  it('routes whole-file descriptor APIs through the mounted namespace', async () => {
+    // Given: an open descriptor for a file below a non-root mount.
+    registerPlugin('indexeddb-isolation', createIndexedDBStoragePlugin);
+    usePlugin('indexeddb-isolation', { mountPath: '/data' });
+    await fs.promises.writeFile(
+      '/data/file.txt',
+      Buffer.fromString('before'),
+      'utf8'
+    );
+    const handle = await fs.promises.open('/data/file.txt', 'r+');
+
+    // When: whole-file read, overwrite, and append APIs receive the descriptor.
+    await expect(fs.promises.readFile(handle.fd, 'utf8')).resolves.toBe(
+      'before'
+    );
+    await fs.promises.writeFile(handle.fd, Buffer.fromString('after'));
+    await fs.promises.appendFile(handle.fd, Buffer.fromString('-appended'));
+    await fs.promises.close(handle.fd);
+
+    // Then: all operations affect the mounted file rather than the base root.
+    await expect(fs.promises.readFile('/data/file.txt', 'utf8')).resolves.toBe(
+      'after-appended'
+    );
+  });
+
+  it('writes string chunks through a mounted write stream', async () => {
+    // Given: a write stream targeting a non-root IndexedDB mount.
+    registerPlugin('indexeddb-isolation', createIndexedDBStoragePlugin);
+    usePlugin('indexeddb-isolation', { mountPath: '/data' });
+    const stream = fs.createWriteStream('/data/stream.txt');
+
+    // When: a caller ends the stream with text.
+    await stream.end('stream-value');
+
+    // Then: the text is encoded and persisted inside the mount.
+    await expect(
+      fs.promises.readFile('/data/stream.txt', 'utf8')
+    ).resolves.toBe('stream-value');
+  });
+});

--- a/packages/plugin-indexeddb/src/index.ts
+++ b/packages/plugin-indexeddb/src/index.ts
@@ -1,44 +1,225 @@
 import type {
+  BufferEncoding,
+  Dirent,
   FsPluginContext,
   FsPluginFactory,
 } from '@system-ui-js/file-system-browser';
+import { createFileDescriptorHandlers } from './file-descriptors';
+import { createWriteStreamFactory } from './write-stream';
 
 export interface IndexedDBStoragePluginOptions {
   mountPath?: string;
 }
 
+type EncOpt =
+  | { encoding?: BufferEncoding | null; flag?: string }
+  | BufferEncoding
+  | null;
+
+type WriteOpt =
+  | { encoding?: BufferEncoding | null; mode?: number | string; flag?: string }
+  | BufferEncoding
+  | null;
+
+function norm(path: string): string {
+  const absolute = path.startsWith('/') ? path : `/${path}`;
+  return absolute !== '/' && absolute.endsWith('/')
+    ? absolute.slice(0, -1)
+    : absolute;
+}
+
 export const createIndexedDBStoragePlugin: FsPluginFactory<
   IndexedDBStoragePluginOptions
-> = (options, ctx: FsPluginContext) => ({
-  match: /^\/(?:.*)$/,
-  mountPath: options.mountPath,
-  handlers: {
-    readFile: ctx.baseFs.readFile,
-    writeFile: ctx.baseFs.writeFile,
-    appendFile: ctx.baseFs.appendFile,
-    rename: ctx.baseFs.rename,
-    copyFile: ctx.baseFs.copyFile,
-    mkdir: ctx.baseFs.mkdir,
-    readdir: ctx.baseFs.readdir,
-    rm: ctx.baseFs.rm,
-    unlink: ctx.baseFs.unlink,
-    rmdir: ctx.baseFs.rmdir,
-    stat: ctx.baseFs.stat,
-    lstat: ctx.baseFs.lstat,
-    readlink: ctx.baseFs.readlink,
-    symlink: ctx.baseFs.symlink,
-    link: ctx.baseFs.link,
-    exists: ctx.baseFs.exists,
-    access: ctx.baseFs.access,
-    nlink: ctx.baseFs.nlink,
-    open: ctx.baseFs.open,
-    read: ctx.baseFs.read,
-    write: ctx.baseFs.write,
-    close: ctx.baseFs.close,
-    watch: ctx.baseWatch,
-    watchFile: ctx.baseWatchFile,
-    unwatchFile: ctx.baseUnwatchFile,
-    createReadStream: ctx.baseCreateReadStream,
-    createWriteStream: ctx.baseCreateWriteStream,
-  },
-});
+> = (options, ctx: FsPluginContext) => {
+  const namespaceKey = norm(options.mountPath ?? '/');
+  const namespace = `/.fs-plugin-indexeddb/${encodeURIComponent(namespaceKey)}`;
+  const namespaceReady = ctx.baseFs.mkdir(namespace, { recursive: true });
+  const toStoragePath = (path: string) => {
+    const local = norm(path);
+    return local === '/' ? namespace : `${namespace}${local}`;
+  };
+  const toLocalTarget = (target: string) => {
+    const normalized = norm(target);
+    if (namespaceKey === '/') return normalized;
+    if (normalized === namespaceKey) return '/';
+    if (normalized.startsWith(`${namespaceKey}/`)) {
+      return normalized.slice(namespaceKey.length);
+    }
+    return normalized;
+  };
+  const toPublicTarget = (target: string) => {
+    if (target === namespace) return '/';
+    return target.startsWith(`${namespace}/`)
+      ? target.slice(namespace.length)
+      : target;
+  };
+  const createWriteStream = createWriteStreamFactory(
+    ctx,
+    namespaceReady,
+    toStoragePath
+  );
+  const fileDescriptorHandlers = createFileDescriptorHandlers(
+    ctx,
+    namespaceReady,
+    toStoragePath
+  );
+  function readdirIndexedDB(
+    path: string,
+    readdirOptions:
+      | {
+          withFileTypes: true;
+          encoding?: BufferEncoding;
+        }
+      | BufferEncoding
+  ): Promise<Dirent[]>;
+  function readdirIndexedDB(
+    path: string,
+    readdirOptions?:
+      | {
+          withFileTypes?: false;
+          encoding?: BufferEncoding;
+        }
+      | BufferEncoding
+  ): Promise<string[]>;
+  async function readdirIndexedDB(
+    path: string,
+    readdirOptions?:
+      | { withFileTypes?: boolean; encoding?: BufferEncoding }
+      | BufferEncoding
+  ): Promise<Array<Dirent | string>> {
+    await namespaceReady;
+    if (
+      typeof readdirOptions === 'object' &&
+      readdirOptions.withFileTypes === true
+    ) {
+      return ctx.baseFs.readdir(toStoragePath(path), {
+        withFileTypes: true,
+        encoding: readdirOptions.encoding,
+      });
+    }
+    const namesOptions =
+      typeof readdirOptions === 'object'
+        ? {
+            withFileTypes: false as const,
+            encoding: readdirOptions.encoding,
+          }
+        : readdirOptions;
+    return ctx.baseFs.readdir(toStoragePath(path), namesOptions);
+  }
+
+  return {
+    match: /^\/(?:.*)$/,
+    mountPath: options.mountPath,
+    handlers: {
+      async readFile(path: string | number, readOptions?: EncOpt) {
+        await namespaceReady;
+        const storagePath =
+          typeof path === 'number'
+            ? fileDescriptorHandlers.getStorageFd(path, 'readFile')
+            : toStoragePath(path);
+        return ctx.baseFs.readFile(storagePath, readOptions);
+      },
+      async writeFile(
+        path: string | number,
+        data: Iterable<number>,
+        writeOptions?: WriteOpt
+      ) {
+        await namespaceReady;
+        const storagePath =
+          typeof path === 'number'
+            ? fileDescriptorHandlers.getStorageFd(path, 'writeFile')
+            : toStoragePath(path);
+        await ctx.baseFs.writeFile(storagePath, data, writeOptions);
+      },
+      async appendFile(
+        path: string | number,
+        data: Iterable<number>,
+        writeOptions?: WriteOpt
+      ) {
+        await namespaceReady;
+        const storagePath =
+          typeof path === 'number'
+            ? fileDescriptorHandlers.getStorageFd(path, 'appendFile')
+            : toStoragePath(path);
+        await ctx.baseFs.appendFile(storagePath, data, writeOptions);
+      },
+      async rename(from: string, to: string) {
+        await namespaceReady;
+        await ctx.baseFs.rename(toStoragePath(from), toStoragePath(to));
+      },
+      async copyFile(from: string, to: string) {
+        await namespaceReady;
+        await ctx.baseFs.copyFile(toStoragePath(from), toStoragePath(to));
+      },
+      async mkdir(path: string, mkdirOptions) {
+        await namespaceReady;
+        await ctx.baseFs.mkdir(toStoragePath(path), mkdirOptions);
+      },
+      readdir: readdirIndexedDB,
+      async rm(path: string, rmOptions) {
+        await namespaceReady;
+        await ctx.baseFs.rm(toStoragePath(path), rmOptions);
+      },
+      async unlink(path: string) {
+        await namespaceReady;
+        await ctx.baseFs.unlink(toStoragePath(path));
+      },
+      async rmdir(path: string, rmdirOptions) {
+        await namespaceReady;
+        await ctx.baseFs.rmdir(toStoragePath(path), rmdirOptions);
+      },
+      async stat(path: string) {
+        await namespaceReady;
+        return ctx.baseFs.stat(toStoragePath(path));
+      },
+      async lstat(path: string) {
+        await namespaceReady;
+        return ctx.baseFs.lstat(toStoragePath(path));
+      },
+      async readlink(path: string) {
+        await namespaceReady;
+        return toPublicTarget(await ctx.baseFs.readlink(toStoragePath(path)));
+      },
+      async symlink(target: string, path: string) {
+        await namespaceReady;
+        await ctx.baseFs.symlink(
+          toStoragePath(toLocalTarget(target)),
+          toStoragePath(path)
+        );
+      },
+      async link(existingPath: string, newPath: string) {
+        await namespaceReady;
+        await ctx.baseFs.link(
+          toStoragePath(existingPath),
+          toStoragePath(newPath)
+        );
+      },
+      async exists(path: string) {
+        await namespaceReady;
+        return ctx.baseFs.exists(toStoragePath(path));
+      },
+      async access(path: string, mode?: number) {
+        await namespaceReady;
+        await ctx.baseFs.access(toStoragePath(path), mode);
+      },
+      async nlink(path: string) {
+        await namespaceReady;
+        return ctx.baseFs.nlink(toStoragePath(path));
+      },
+      ...fileDescriptorHandlers.handlers,
+      watch(path, listener) {
+        return ctx.baseWatch(toStoragePath(path), listener);
+      },
+      watchFile(path, listener) {
+        ctx.baseWatchFile(toStoragePath(path), listener);
+      },
+      unwatchFile(path, listener) {
+        ctx.baseUnwatchFile(toStoragePath(path), listener);
+      },
+      createReadStream(path, streamOptions) {
+        return ctx.baseCreateReadStream(toStoragePath(path), streamOptions);
+      },
+      createWriteStream,
+    },
+  };
+};

--- a/packages/plugin-indexeddb/src/write-stream.ts
+++ b/packages/plugin-indexeddb/src/write-stream.ts
@@ -1,0 +1,62 @@
+import type { FsPluginContext } from '@system-ui-js/file-system-browser';
+
+type WriteStreamEvents = {
+  finish: () => void;
+  error: (err: unknown) => void;
+};
+
+export function createWriteStreamFactory(
+  ctx: FsPluginContext,
+  namespaceReady: Promise<unknown>,
+  toStoragePath: (path: string) => string
+) {
+  return (path: string) => {
+    const listeners: {
+      [K in keyof WriteStreamEvents]: WriteStreamEvents[K][];
+    } = {
+      finish: [],
+      error: [],
+    };
+    const chunks: Uint8Array[] = [];
+
+    return {
+      async write(chunk: Uint8Array | string) {
+        chunks.push(
+          typeof chunk === 'string'
+            ? ctx.Buffer.fromString(chunk)
+            : new Uint8Array(chunk)
+        );
+        return true;
+      },
+      async end(chunk?: Uint8Array | string) {
+        if (chunk !== undefined) await this.write(chunk);
+        const size = chunks.reduce((total, item) => total + item.length, 0);
+        const data = new Uint8Array(size);
+        let offset = 0;
+        for (const item of chunks) {
+          data.set(item, offset);
+          offset += item.length;
+        }
+
+        try {
+          await namespaceReady;
+          await ctx.baseFs.writeFile(toStoragePath(path), data);
+          listeners.finish.forEach((handler) => {
+            handler();
+          });
+        } catch (err) {
+          listeners.error.forEach((handler) => {
+            handler(err);
+          });
+        }
+      },
+      on<E extends keyof WriteStreamEvents>(
+        event: E,
+        handler: WriteStreamEvents[E]
+      ) {
+        listeners[event].push(handler);
+        return this;
+      },
+    };
+  };
+}

--- a/packages/plugin-indexeddb/vite.config.ts
+++ b/packages/plugin-indexeddb/vite.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'FileSystemPluginIndexedDB',
       formats: ['es', 'umd'],
-      fileName: (format) => `file-system-plugin-indexeddb.${format}.js`,
+      fileName: (format) =>
+        format === 'umd'
+          ? 'file-system-plugin-indexeddb.umd.cjs'
+          : 'file-system-plugin-indexeddb.es.js',
     },
     rollupOptions: {
       external: ['@system-ui-js/file-system-browser'],

--- a/packages/plugin-memory/package.json
+++ b/packages/plugin-memory/package.json
@@ -3,14 +3,13 @@
   "version": "0.1.0",
   "description": "Memory storage plugin for @system-ui-js/file-system-browser",
   "type": "module",
-  "main": "./dist/file-system-plugin-memory.umd.js",
+  "main": "./dist/file-system-plugin-memory.umd.cjs",
   "module": "./dist/file-system-plugin-memory.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "import": "./dist/file-system-plugin-memory.es.js",
-      "require": "./dist/file-system-plugin-memory.umd.js",
+      "require": "./dist/file-system-plugin-memory.umd.cjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/plugin-memory/src/index.ts
+++ b/packages/plugin-memory/src/index.ts
@@ -383,6 +383,11 @@ export const createMemoryStoragePlugin: FsPluginFactory<
         `ENOENT: no such file or directory, rename '${oldPath}' -> '${newPath}'`
       );
     }
+    if (entry.type === 'directory' && newPath.startsWith(`${oldPath}/`)) {
+      throw new Error(
+        `EINVAL: cannot move directory into itself, rename '${oldPath}' -> '${newPath}'`
+      );
+    }
     ensureParentDirectory(newPath, 'rename');
     const existing = entries.get(newPath);
     if (

--- a/packages/plugin-memory/src/memory-plugin.test.ts
+++ b/packages/plugin-memory/src/memory-plugin.test.ts
@@ -118,6 +118,22 @@ describe('memory storage plugin', () => {
     ).resolves.toBe('copy');
   });
 
+  it('rejects moving a directory into its own descendant', async () => {
+    // Given: a populated directory tree.
+    mountMemory();
+    await fs.promises.mkdir('/memory/a');
+    await fs.promises.writeFile('/memory/a/file.txt', 'safe', 'utf8');
+
+    // When: rename would make the directory its own ancestor.
+    const rename = fs.promises.rename('/memory/a', '/memory/a/b');
+
+    // Then: the invalid move is rejected without corrupting the original tree.
+    await expect(rename).rejects.toThrow('EINVAL');
+    await expect(
+      fs.promises.readFile('/memory/a/file.txt', 'utf8')
+    ).resolves.toBe('safe');
+  });
+
   it('supports symlink/readlink and detects symlink loops', async () => {
     mountMemory();
 

--- a/packages/plugin-memory/vite.config.ts
+++ b/packages/plugin-memory/vite.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'FileSystemPluginMemory',
       formats: ['es', 'umd'],
-      fileName: (format) => `file-system-plugin-memory.${format}.js`,
+      fileName: (format) =>
+        format === 'umd'
+          ? 'file-system-plugin-memory.umd.cjs'
+          : 'file-system-plugin-memory.es.js',
     },
     rollupOptions: {
       external: ['@system-ui-js/file-system-browser'],

--- a/packages/plugin-webdav/package.json
+++ b/packages/plugin-webdav/package.json
@@ -3,14 +3,13 @@
   "version": "0.1.0",
   "description": "WebDAV storage plugin for @system-ui-js/file-system-browser",
   "type": "module",
-  "main": "./dist/file-system-plugin-webdav.umd.js",
+  "main": "./dist/file-system-plugin-webdav.umd.cjs",
   "module": "./dist/file-system-plugin-webdav.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ts",
       "import": "./dist/file-system-plugin-webdav.es.js",
-      "require": "./dist/file-system-plugin-webdav.umd.js",
+      "require": "./dist/file-system-plugin-webdav.umd.cjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/packages/plugin-webdav/src/index.ts
+++ b/packages/plugin-webdav/src/index.ts
@@ -32,7 +32,10 @@ type WebDAVClient = {
     options: { format: 'binary' }
   ): Promise<unknown>;
   putFileContents(path: string, data: Uint8Array): Promise<unknown>;
-  createDirectory(path: string): Promise<unknown>;
+  createDirectory(
+    path: string,
+    options?: { recursive?: boolean }
+  ): Promise<unknown>;
   getDirectoryContents(
     path: string
   ): Promise<WebDAVFileStat[] | WebDAVFileStat>;
@@ -149,6 +152,17 @@ async function webdavCall<T>(
   } catch (error) {
     throw readableError(error, operation, path);
   }
+}
+
+function isNotFound(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null) {
+    if ('status' in error) return error.status === 404;
+    if ('statusCode' in error) return error.statusCode === 404;
+  }
+  return (
+    error instanceof Error &&
+    /^(?:Invalid response:\s*)?404(?:\s|$)/i.test(error.message)
+  );
 }
 
 export const createWebDAVStoragePlugin: FsPluginFactory<
@@ -293,13 +307,33 @@ export const createWebDAVStoragePlugin: FsPluginFactory<
           await webdavCall('lstat', remote, () => client.stat(remote))
         );
       },
-      async mkdir(path: string) {
+      async mkdir(
+        path: string,
+        options?:
+          | number
+          | string
+          | { recursive?: boolean; mode?: number | string }
+      ) {
         const remote = toRemote(path);
-        await webdavCall('mkdir', remote, () => client.createDirectory(remote));
+        const recursive =
+          typeof options === 'object' ? options.recursive : undefined;
+        await webdavCall('mkdir', remote, () =>
+          recursive === undefined
+            ? client.createDirectory(remote)
+            : client.createDirectory(remote, { recursive })
+        );
       },
-      async rm(path: string) {
+      async rm(
+        path: string,
+        options?: { recursive?: boolean; force?: boolean }
+      ) {
         const remote = toRemote(path);
-        await webdavCall('rm', remote, () => client.deleteFile(remote));
+        try {
+          await client.deleteFile(remote);
+        } catch (error) {
+          if (options?.force && isNotFound(error)) return;
+          throw readableError(error, 'rm', remote);
+        }
       },
       async unlink(path: string) {
         const remote = toRemote(path);

--- a/packages/plugin-webdav/src/webdav-plugin.test.ts
+++ b/packages/plugin-webdav/src/webdav-plugin.test.ts
@@ -254,6 +254,50 @@ describe('WebDAV storage plugin', () => {
     );
   });
 
+  it('forwards recursive directory creation to WebDAV', async () => {
+    // Given: a WebDAV-backed mount.
+    const { client, handlers } = makePlugin();
+
+    // When: callers request recursive directory creation.
+    await handlers.mkdir('/parent/child', { recursive: true });
+
+    // Then: the WebDAV client receives the recursive option.
+    expect(client.createDirectory).toHaveBeenCalledWith(
+      '/remote/root/parent/child',
+      { recursive: true }
+    );
+  });
+
+  it('ignores missing paths when rm uses force', async () => {
+    // Given: the WebDAV server reports that the path is missing.
+    const { client, handlers } = makePlugin();
+    client.deleteFile.mockRejectedValue(
+      Object.assign(new Error('Invalid response: 404 Not Found'), {
+        status: 404,
+      })
+    );
+
+    // When/Then: force makes removal idempotent.
+    await expect(
+      handlers.rm('/missing.txt', { force: true })
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not hide structured non-404 errors when rm uses force', async () => {
+    // Given: an upstream failure whose message happens to mention 404.
+    const { client, handlers } = makePlugin();
+    client.deleteFile.mockRejectedValue(
+      Object.assign(new Error('503 response included prior 404 details'), {
+        status: 503,
+      })
+    );
+
+    // When/Then: force still surfaces failures other than a missing target.
+    await expect(handlers.rm('/file.txt', { force: true })).rejects.toThrow(
+      "WebDAV rm request failed for '/remote/root/file.txt'"
+    );
+  });
+
   it('throws exact deterministic ENOTSUP errors for unsupported operations', async () => {
     const { handlers } = makePlugin();
     const unsupportedCases: Array<[string, unknown[], string]> = [

--- a/packages/plugin-webdav/vite.config.ts
+++ b/packages/plugin-webdav/vite.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'FileSystemPluginWebDAV',
       formats: ['es', 'umd'],
-      fileName: (format) => `file-system-plugin-webdav.${format}.js`,
+      fileName: (format) =>
+        format === 'umd'
+          ? 'file-system-plugin-webdav.umd.cjs'
+          : 'file-system-plugin-webdav.es.js',
     },
     rollupOptions: {
       external: ['@system-ui-js/file-system-browser'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,9 +16,6 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        launchOptions: {
-          executablePath: '/tmp/chrome-extract/opt/google/chrome/chrome',
-        },
       },
     },
   ],


### PR DESCRIPTION
## Summary
- 修复 IndexedDB 多挂载路径串扰：每挂载点独立命名空间，fd 与 write stream 映射到真实底层句柄，并新增回归测试
- 修复 memory 插件将目录 rename 到自身后代导致的幽灵树（抛 EINVAL）；webdav 支持 recursive mkdir 与 force rm（仅吞真实 404）
- 修复四包 CJS require 空导出（改为 .umd.cjs）与无效 source export；移除硬编码 Chrome 路径并在发布工作流 E2E 前安装 Chromium

## Testing
- `yarn test:unit --run`：5 files / 69 tests passed
- `yarn test:e2e`：Chromium 27/27 passed
- `yarn build`：四个 workspace 全部通过；`yarn lint`：0 errors
- 真实 CommonJS `require()` 与 npm pack 内容核对通过；构建产物 fake-indexeddb 驱动验证隔离/fd/stream
